### PR TITLE
Fix: do not drop parallel row bounds when merging into an equality

### DIFF
--- a/src/explorers/Parallel_rows.c
+++ b/src/explorers/Parallel_rows.c
@@ -369,6 +369,15 @@ static inline PresolveStatus process_single_bin(const Constraints *constraints,
 
         if (!is_remaining_row_eq && is_other_row_eq)
         {
+            // check the sides accumulated so far before the swap discards them
+            double eq_scaled = rhs[other_row_idx] * (remaining_row_coeff /
+                                                     A->x[A->p[other_row_idx].start]);
+            if ((!is_rhs_inf_remaining_row && eq_scaled > remaining_row_new_rhs) ||
+                (!is_lhs_inf_remaining_row && eq_scaled < remaining_row_new_lhs))
+            {
+                return INFEASIBLE;
+            }
+
             // swap(remaining_row, other_row)
             int temp = remaining_row_idx;
             remaining_row_idx = other_row_idx;

--- a/src/explorers/Parallel_rows.c
+++ b/src/explorers/Parallel_rows.c
@@ -370,8 +370,9 @@ static inline PresolveStatus process_single_bin(const Constraints *constraints,
         if (!is_remaining_row_eq && is_other_row_eq)
         {
             // check the sides accumulated so far before the swap discards them
-            double eq_scaled = rhs[other_row_idx] * (remaining_row_coeff /
-                                                     A->x[A->p[other_row_idx].start]);
+            double eq_scaled =
+                rhs[other_row_idx] *
+                (remaining_row_coeff / A->x[A->p[other_row_idx].start]);
             if ((!is_rhs_inf_remaining_row && eq_scaled > remaining_row_new_rhs) ||
                 (!is_lhs_inf_remaining_row && eq_scaled < remaining_row_new_lhs))
             {

--- a/tests/test_Parallel_rows.h
+++ b/tests/test_Parallel_rows.h
@@ -1260,6 +1260,50 @@ static char *test_16_parallel_rows()
     return 0;
 }
 
+/*  Infeasible problem. The row that contradicts the equality is not the first
+    one in the bin, so it is only caught if the sides accumulated before the
+    equality becomes the remaining row are checked against it.
+    min.   [0 0 0] x
+    s.t.   0 <= x1 + x2 + x3 <= 5
+           0 <= x1 + x2 + x3 <= 20
+                x1 + x2 + x3 = 10
+*/
+static char *test_17_parallel_rows()
+{
+    double Ax[] = {1, 1, 1, 1, 1, 1, 1, 1, 1};
+    int Ai[] = {0, 1, 2, 0, 1, 2, 0, 1, 2};
+    int Ap[] = {0, 3, 6, 9};
+    int nnz = 9;
+    int n_rows = 3;
+    int n_cols = 3;
+
+    double lhs[] = {0, 0, 10};
+    double rhs[] = {5, 20, 10};
+    double lbs[] = {0, 0, 0};
+    double ubs[] = {100, 100, 100};
+    double c[] = {0, 0, 0};
+
+    Settings *stgs = default_settings();
+    Presolver *presolver =
+        new_presolver(Ax, Ai, Ap, n_rows, n_cols, nnz, lhs, rhs, lbs, ubs, c, stgs);
+
+    Problem *prob = presolver->prob;
+    Constraints *constraints = prob->constraints;
+    Matrix *A = constraints->A;
+    PresolveStatus status = remove_parallel_rows(constraints);
+    mu_assert("error", status == INFEASIBLE);
+    problem_clean(prob, true);
+
+    mu_assert("error Ax", ARRAYS_EQUAL_DOUBLE(Ax, A->x, nnz));
+    mu_assert("error Ai", ARRAYS_EQUAL_INT(Ai, A->i, nnz));
+    mu_assert("rows", check_row_starts(A, Ap));
+
+    PS_FREE(stgs);
+    DEBUG(run_debugger(constraints, false));
+    free_presolver(presolver);
+    return 0;
+}
+
 static const char *all_tests_parallel_rows()
 {
     mu_run_test(test_1_parallel_rows, counter_parallel_rows);
@@ -1278,6 +1322,7 @@ static const char *all_tests_parallel_rows()
     mu_run_test(test_14_parallel_rows, counter_parallel_rows);
     mu_run_test(test_15_parallel_rows, counter_parallel_rows);
     mu_run_test(test_16_parallel_rows, counter_parallel_rows);
+    mu_run_test(test_17_parallel_rows, counter_parallel_rows);
 
     return 0;
 }


### PR DESCRIPTION
Closes #50.

When an equality row becomes the remaining row of a bin, the sides accumulated from the rows processed before it were dropped without being checked. Those rows are deleted at the end of the merge, so a bound they carried could vanish and leave the reduced problem weaker than the original.

The fix compares the equality against those sides before the swap discards them. That comparison is also what makes discarding them sound: if the equality lies inside them, it is the tighter constraint, and they are redundant; and if it lies outside, the bin is infeasible.

`test_17_parallel_rows` is the case from the issue. It fails on the current main in both Debug and Release.