### PR TITLE
fix: skip already-inactive columns in remove_empty_cols() to avoid double-counted obj_offset

### DIFF
--- a/src/explorers/SimpleReductions.c
+++ b/src/explorers/SimpleReductions.c
@@ -529,6 +529,11 @@ PresolveStatus remove_empty_cols(Problem *prob)
     {
         k = empty_cols_data[i];
 
+        if (HAS_TAG(col_tags[k], C_TAG_INACTIVE))
+        {
+            continue;
+        }
+
         assert(col_sizes[k] == 0 && !HAS_TAG(col_tags[k], C_TAG_INACTIVE));
 
         // --------------------------------------------------------------------


### PR DESCRIPTION
Problem

remove_empty_cols() in src/explorers/SimpleReductions.c can add c[k] * val to obj->offset more than once for the same column, causing the reported objective to be too large by a constant. The postsolved primal/dual solution is unaffected only the offset bookkeeping is wrong.

Root cause: execute_substitution() in DtonsEq.c appends a column to state->empty_cols whenever its size drops to zero. The two guards at the append site are asserts, so in an NDEBUG build a column that has already been fixed can still be appended -- and can be appended more than once -- because remove_dton_eq_rows() defers delete_fixed_cols_from_problem() until after its doubleton loop. When remove_empty_cols() later iterates over the list, it processes each entry without checking whether the column was already handled, accumulating c[k]*val into the offset and emitting a FIXED_COL postsolve record each time.

Observed on a large LP (4.79M rows / 15.07M cols / 47.6M nnz):

```
                                           before fix                          after fix
  obj_offset                       1.354463042e+10     9.178414252e+09
  duplicate offset adds   17437                                  0
  postsolved objective   1.417248474e+10     9.806268572e+09
  invariant error               4.366216165e+09     9.7e-05
```

The reduced problem is bit-identical before and after; only the offset accumulation changes.

Fix

Skip columns that are already tagged C_TAG_INACTIVE at the top of the loop in remove_empty_cols(). The first pass through the loop tags the column FIXED, so a duplicate entry is silently ignored on the second pass.

```
    if (HAS_TAG(col_tags[k], C_TAG_INACTIVE))
    {
        continue;
    }
```
