### PR TITLE
Respect verbose=false in print_infeas_or_unbnd_message

### DIFF
--- a/src/core/Presolver.c
+++ b/src/core/Presolver.c
@@ -720,7 +720,10 @@ PresolveStatus run_presolver(Presolver *presolver)
     if (status != UNCHANGED)
     {
         // problem detected to be infeasible or unbounded
-        print_infeas_or_unbnd_message(status);
+        if (stgs->verbose)
+        {
+            print_infeas_or_unbnd_message(status);
+        }
         return status;
     }
 


### PR DESCRIPTION
## Summary

`run_presolver()` gates every other console message behind `stgs->verbose` (`print_start_message`, `print_end_message`), but calls `print_infeas_or_unbnd_message()` unconditionally when the problem is detected infeasible or unbounded:

```c
if (status != UNCHANGED)
{
    // problem detected to be infeasible or unbounded
    print_infeas_or_unbnd_message(status);
    return status;
}
```

A caller that sets `verbose = false` to keep PSLP silent still gets `PSLP declares problem as infeasible.` (or the unbounded variant) printed directly to stdout for exactly that one case.

## Why this matters

Found while embedding PSLP in [cuOpt's Java bindings](https://github.com/NVIDIA/cuopt): the caller there already sets `verbose = false`, but this one unconditional `printf` writes directly to the process's native stdout stream. In a JVM host, that bypasses `System.out` and can corrupt tooling that intercepts stdout for its own purposes -- in our case, Maven Surefire's forked-JVM communication protocol, which uses stdout as its own IPC channel and reports a false "VM crash" when an unexpected raw write lands mid-frame.

## Fix

Gate the call the same way the surrounding code already gates the other two messages in this function:

```c
if (status != UNCHANGED)
{
    // problem detected to be infeasible or unbounded
    if (stgs->verbose)
    {
        print_infeas_or_unbnd_message(status);
    }
    return status;
}
```
