### PR TITLE
Do not fix empty columns in remove_variables_with_close_bounds

### DIFF
--- a/src/core/Presolver.c
+++ b/src/core/Presolver.c
@@ -331,13 +331,13 @@ Presolver *new_presolver(const double *Ax, const int *Ai, const int *Ap, size_t 
     return presolver;
 
 cleanup:
-    {
-        struct clean_up_scope scope = {
-            A,         AT,       lhs_copy, rhs_copy,   c_copy, row_sizes,
-            col_sizes, row_tags, locks,    activities, data,   constraints,
-            presolver, obj,      col_tags, bounds,     work};
-        presolver_clean_up(scope);
-    }
+{
+    struct clean_up_scope scope = {
+        A,         AT,       lhs_copy, rhs_copy,   c_copy, row_sizes,
+        col_sizes, row_tags, locks,    activities, data,   constraints,
+        presolver, obj,      col_tags, bounds,     work};
+    presolver_clean_up(scope);
+}
     return NULL;
 }
 

--- a/src/core/Presolver.c
+++ b/src/core/Presolver.c
@@ -331,13 +331,13 @@ Presolver *new_presolver(const double *Ax, const int *Ai, const int *Ap, size_t 
     return presolver;
 
 cleanup:
-{
-    struct clean_up_scope scope = {
-        A,         AT,       lhs_copy, rhs_copy,   c_copy, row_sizes,
-        col_sizes, row_tags, locks,    activities, data,   constraints,
-        presolver, obj,      col_tags, bounds,     work};
-    presolver_clean_up(scope);
-}
+    {
+        struct clean_up_scope scope = {
+            A,         AT,       lhs_copy, rhs_copy,   c_copy, row_sizes,
+            col_sizes, row_tags, locks,    activities, data,   constraints,
+            presolver, obj,      col_tags, bounds,     work};
+        presolver_clean_up(scope);
+    }
     return NULL;
 }
 

--- a/src/explorers/SimpleReductions.c
+++ b/src/explorers/SimpleReductions.c
@@ -694,14 +694,18 @@ PresolveStatus remove_variables_with_close_bounds(Problem *prob)
 
         assert(!HAS_TAG(col_tags[ii], C_TAG_INACTIVE));
 
-        if (IS_EQUAL_FEAS_TOL(bounds[ii].lb, bounds[ii].ub))
+        if (bounds[ii].lb > bounds[ii].ub + FEAS_TOL)
+        {
+            return INFEASIBLE;
+        }
+
+        // Empty columns are fixed by remove_empty_cols (fix_col requires a
+        // non-empty column); fixing them here as well would add their
+        // objective contribution to the offset twice.
+        if (col_sizes[ii] > 0 && IS_EQUAL_FEAS_TOL(bounds[ii].lb, bounds[ii].ub))
         {
             // no need to check return value since bounds are equal
             fix_col(constraints, (int) ii, bounds[ii].lb, c[ii]);
-        }
-        else if (bounds[ii].lb > bounds[ii].ub + FEAS_TOL)
-        {
-            return INFEASIBLE;
         }
     }
 

--- a/tests/test_Presolver.h
+++ b/tests/test_Presolver.h
@@ -7,6 +7,7 @@
 #include "Problem.h"
 #include "Workspace.h"
 #include "minunit.h"
+#include <math.h>
 #include <stdio.h>
 
 static int counter_presolver = 0;
@@ -90,10 +91,56 @@ static char *test_01_presolver()
     return 0;
 }
 
+/* A column that is both empty (no entries in A) and fixed (lb == ub) must
+   contribute c * x to the objective offset exactly once. Previously
+   remove_variables_with_close_bounds fixed it and remove_empty_cols fixed it
+   again, doubling its contribution (Netlib 80bau3b has 107 such columns). */
+static char *test_02_presolver()
+{
+    // min -x0 - x1 + 7 x2  s.t.  x0 + 2 x1 <= 4,  3 x0 + x1 <= 6,
+    //                             0 <= x0, x1 <= 10,  x2 = 3 (empty column)
+    double Ax[] = {1, 2, 3, 1};
+    int Ai[] = {0, 1, 0, 1};
+    int Ap[] = {0, 2, 4};
+    int nnz = 4;
+    int n_rows = 2;
+    int n_cols = 3;
+    double lhs[] = {-INF, -INF};
+    double rhs[] = {4, 6};
+    double lbs[] = {0, 0, 3};
+    double ubs[] = {10, 10, 3};
+    double c[] = {-1, -1, 7};
+
+    Settings *stgs = default_settings();
+    stgs->verbose = false;
+    Presolver *presolver =
+        new_presolver(Ax, Ai, Ap, n_rows, n_cols, nnz, lhs, rhs, lbs, ubs, c, stgs);
+    mu_assert("Presolver initialization failed", presolver != NULL);
+
+    run_presolver(presolver);
+
+    mu_assert("empty fixed column not removed", presolver->reduced_prob->n == 2);
+    mu_assert("objective offset of empty fixed column counted more than once",
+              fabs(presolver->reduced_prob->obj_offset - 21.0) < 1e-12);
+
+    // the reduced problem's optimum is x = (1.6, 1.2); postsolve must put the
+    // fixed column back at its bound
+    double x[] = {1.6, 1.2};
+    double y[] = {-0.4, -0.2};
+    double z[] = {0, 0};
+    postsolve(presolver, x, y, z);
+    mu_assert("postsolved value of empty fixed column", presolver->sol->x[2] == 3.0);
+
+    PS_FREE(stgs);
+    free_presolver(presolver);
+    return 0;
+}
+
 static const char *all_tests_presolver()
 {
     mu_run_test(test_00_presolver, counter_presolver);
     mu_run_test(test_01_presolver, counter_presolver);
+    mu_run_test(test_02_presolver, counter_presolver);
     return 0;
 }
 


### PR DESCRIPTION
## Summary

A column that is both empty (no entries in A) and fixed (lb == ub) was fixed twice during presolve: once in `remove_variables_with_close_bounds` through `fix_col`, and again in `remove_empty_cols`. Its objective contribution therefore entered `obj_offset` twice. On Netlib 80bau3b (107 such columns) the reported objective was 1414647.85 instead of 987224.19; the postsolved solution itself was correct.

#53 hid the double count by skipping inactive columns in `remove_empty_cols`, but the empty column still reaches `fix_col`, which asserts `col_sizes[col] > 0` and aborts in Debug builds.

This PR leaves empty columns to `remove_empty_cols` and keeps only the `lb > ub` infeasibility check for them in `remove_variables_with_close_bounds`.

## Test

- New `test_02_presolver`: 3-variable LP with an empty column fixed at 3 and cost 7. Checks that the reduced problem has 2 columns, `obj_offset` is exactly 21, and postsolve restores the column to 3. On current main this test aborts on the `fix_col` assertion in a Debug build.
- All existing tests pass (`-DCMAKE_BUILD_TYPE=Debug -DPSLP_BUILD_TESTING=ON`).
- cuPDLPx built against this branch: 80bau3b with presolve gives 987224.19, matching `--no_presolve` and HiGHS.

Related issue: https://github.com/MIT-Lu-Lab/cuPDLPx/issues/104